### PR TITLE
Use ClusterRole for chaostoolkit-role.yaml

### DIFF
--- a/manifests/base/common/configmap.yaml
+++ b/manifests/base/common/configmap.yaml
@@ -18,7 +18,7 @@ data:
 
   chaostoolkit-role.yaml: |-
     apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
+    kind: ClusterRole
     metadata:
       name: chaostoolkit-experiment
     rules:
@@ -50,7 +50,7 @@ data:
       name: chaostoolkit-experiment
     roleRef:
       apiGroup: rbac.authorization.k8s.io
-      kind: Role
+      kind: ClusterRole
       name: chaostoolkit-experiment
     subjects:
     - kind: ServiceAccount

--- a/manifests/base/common/crd.yaml
+++ b/manifests/base/common/crd.yaml
@@ -24,6 +24,12 @@ spec:
             spec:
               type: object
               x-kubernetes-preserve-unknown-fields: true
+              properties:
+                clusterRoleBindNamespaces:
+                  type: array
+                  nullable: true
+                  items:
+                    type: string
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/manifests/base/rbac/clusterrole.yaml
+++ b/manifests/base/rbac/clusterrole.yaml
@@ -53,6 +53,7 @@ rules:
   resources:
   - roles
   - rolebindings
+  - clusterroles
   verbs:
   - create
   - delete


### PR DESCRIPTION
This PR modifies the CRD to use ClusterRoles + RoleBindings by default, instead of using Roles + RoleBindings.

As part of initial technical exploration using `chaostoolkit/kubernetes-crd`, I wanted to quickly test the `chaostoolkit-kubernetes` extensions with the CRD. After building my own runner docker image, I still was unable to modify resources outside of the `chaostoolkit-run` namespace. I see this path as being critical for first line evaluation of the crd: users will incorporate the CRD and manifests into their clusters, and then want to be able to operate on any namespace from the experiment pod.

I updated the CRD schema to support a new spec property, `clusterRoleBindNamespaces`. Each namespace specified in the list will generate an additional RoleBinding, allowing the service account associated with an experiment to interact with the k8s api for the given namespace.

A user defines an experiment as follows:

```
apiVersion: chaostoolkit.org/v1
kind: ChaosToolkitExperiment
metadata:
  name: chaostoolkit-experiment
  namespace: chaostoolkit-crd
spec:
  namespace: chaostoolkit-run
  pod:
    image: <PRIVATE>.com/chaostoolkit:latest
  clusterRoleBindNamespaces:
  - sock-shop
```

Now, the experiment role in the `chaostoolkit-experiment` ConfigMap will be bound to the `sock-shop` namespace, allowing chaostoolkit-kubernetes to perform actions on the target namespace, and no others. 